### PR TITLE
Bug Fix: Disable mouse wheel scroll on CastScroller

### DIFF
--- a/src/styles/layouts/contentPage.css
+++ b/src/styles/layouts/contentPage.css
@@ -497,8 +497,7 @@
     position: relative;
     width: 100%;
     height: 220px;
-    overflow-x: auto;
-    overflow-y: hidden;
+    overflow: hidden;
     white-space: nowrap;
     transition: transform 0.15s ease;
     -ms-overflow-style: none;


### PR DESCRIPTION
Fixes a bug where unintended scrolling occurred on the CastScroller component when using the mouse wheel. This was resolved by preventing the default mouse wheel behavior on the component's container.